### PR TITLE
Update tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,17 @@ If you haven't opened a pull request before on Github follow the below instructi
 6) Add @RevatureGentry and @KennethDavis391 as approvers to your request
 7) Select open pull request and viola pull request in progress! Will and Kenneth will comment once they review and merge it in if there are no issues.
 
+### Note on tsconfig.json "skipLibCheck": true setting:
+An imported library (saturn-datepicker) that integrated with angular material had a bug in one of its files that caused ng build errors:
+https://github.com/SaturnTeam/saturn-datepicker/issues/157
+
+`Error: node_modules/saturn-datepicker/datepicker/datepicker.d.ts:57:22`
+
+`node_modules/@angular/material/core/common-behaviors/color.d.ts:15:5`
+
+To solve this issue, we could have edited the node_module file by hand, but that would be manual for all users. Instead, we set "skipLibCheck": true in the tsconfig.json, which stops Typescript type-checking for imported libraries and only type-checks the code used against imported library types. Please see the following article for more details:
+https://stackoverflow.com/questions/52311779/usage-of-the-typescript-compiler-argument-skiplibcheck
+
+If you are able to use a more recent version of saturn-datepicker or angular material, it may be worth it to try removing the "skipLibCheck": true setting and trying ng build. If you receive no errors, then this bug will have been fixed.
 * * *
 

--- a/chronicle-front/tsconfig.json
+++ b/chronicle-front/tsconfig.json
@@ -19,7 +19,8 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,


### PR DESCRIPTION
Adding "skipLibCheck": true to thetsconfig.json. When we were ng building, angular material was throwing the bug:

 Error: node_modules/saturn-datepicker/datepicker/datepicker.d.ts:57:22 - error TS2420: Class 'SatDatepicker<D>' incorrectly implementCanColor'.
  Property 'defaultColor' is missing in type 'SatDatepicker<D>' but required in type 'CanColor'.

57 export declare class SatDatepicker<D> implements OnDestroy, CanColor {
                        ~~~~~~~~~~~~~

  node_modules/@angular/material/core/common-behaviors/color.d.ts:15:5
    15     defaultColor: ThemePalette | undefined;
           ~~~~~~~~~~~~
    'defaultColor' is declared here.

An imported library (saturn-datepicker) had a bug in one of its files that wasn't allowing it to compile with angular material:

https://github.com/SaturnTeam/saturn-datepicker/issues/157

This issue was still outstanding, and the only options to fix this and compile our project was to either edit the node_modules by hand, which each user would need to do manually, or add "skipLibCheck": true to the tsconfig.json. Here is what this setting does:

"Enabling --skipLibCheck can help work around these issues. Turning it on will prevent Typescript from type-checking the entire imported libraries. Instead, Typescript will only type-check the code you use against these types. This means that as long as you aren't using the incompatible parts of imported libraries, they'll compile just fine."

-https://stackoverflow.com/questions/52311779/usage-of-the-typescript-compiler-argument-skiplibcheck

We also should add this to the README, so that future groups know we made this setting change.